### PR TITLE
Fixes for scene parameter reset, knob numbering, and LED+sound sync

### DIFF
--- a/arduino/serial_test/serial_test.ino
+++ b/arduino/serial_test/serial_test.ino
@@ -1,7 +1,7 @@
 // Total number of channels supported by the hardware device
 const uint8_t numChannels = 4;
-const uint8_t ledPins[] = {2, 4, 7, 8};
-const uint8_t encoderPins[] = {5, 6, 9, 10};
+const uint8_t ledPins[] = {7, 2, 8, 4};
+const uint8_t encoderPins[] = {9, 5, 10, 6};
 unsigned long currentEncoderValues[] = {0, 0, 0, 0};
 unsigned long previousEncoderValues[] = {0, 0, 0, 0};
 const unsigned long encoderValueThreshold = 2048;

--- a/src/ofApp.cpp
+++ b/src/ofApp.cpp
@@ -72,7 +72,7 @@ void ofApp::draw(){
 		// typing is happening...
 		SM.codeFbo.draw(0, 0, 520,520);
 	}
-    if (SM.pctDelay > FADE_DELAY_MAX && ! SM.isTransitioning) {
+    if (SM.shouldDrawScene && !SM.isTransitioning) {
 		int numParams = MIN(SM.scenes[SM.currentScene]->midiKnobs.size(),4);
 //        cout << "Number of parameters: " << numParams << endl;
 		IM.setCurrentSceneParameterCount(numParams);

--- a/src/scenes/baseScene.h
+++ b/src/scenes/baseScene.h
@@ -53,21 +53,53 @@ public:
     void reset(){
         resetTiming();
         
-        for (int i = 0; i < boolParams.size(); i++){
-            boolParams[i].set(origBoolValues[i]);
-            
-            //origBoolValues.push_back(p.get());
+        
+        ofParameter<bool>   boolParam;
+        ofParameter<int>    intParam;
+        ofParameter<float>  floatParam;
+
+        
+        int boolCount = 0;
+        int intCount = 0;
+        int floatCount = 0;
+        
+        
+        for (auto param : parameters) {
+            if (param->type() == boolParam.type()) {
+                ofParameter<bool> &oldParam = param->cast<bool>();
+                oldParam.set(origBoolValues[boolCount]);
+                boolCount++;
+                
+            } else if (param->type() == intParam.type()) {
+                ofParameter<int> &oldParam = param->cast<int>();
+                
+                oldParam.set(origIntValues[intCount]);
+                intCount++;
+                
+            } else if (param->type() == floatParam.type()) {
+                ofParameter<float> &oldParam = param->cast<float>();
+                oldParam.set(origFloatValues[floatCount]);
+                floatCount++;
+            }
         }
         
-        for (int i = 0; i < intParams.size(); i++){
-            intParams[i].set(origIntValues[i]);
-            //origBoolValues.push_back(p.get());
-        }
-        for (int i = 0; i < floatParams.size(); i++){
-            floatParams[i].set(origFloatValues[i]);
-            cout << "settings " << floatParams[i].getName() << " " << origFloatValues[i] << endl;
-            //origBoolValues.push_back(p.get());
-        }
+//        for (int i = 0; i < boolParams.size(); i++){
+//            boolParams[i].set(origBoolValues[i]);
+//            cout << "settings " << boolParams[i].getName() << " " << origBoolValues[i] << endl;
+//            
+//            //origBoolValues.push_back(p.get());
+//        }
+//        
+//        for (int i = 0; i < intParams.size(); i++){
+//            intParams[i].set(origIntValues[i]);
+//            cout << "settings " << intParams[i].getName() << " " << origIntValues[i] << endl;
+//            //origBoolValues.push_back(p.get());
+//        }
+//        for (int i = 0; i < floatParams.size(); i++){
+//            floatParams[i].set(origFloatValues[i]);
+//            cout << "settings " << floatParams[i].getName() << " " << origFloatValues[i] << endl;
+//            //origBoolValues.push_back(p.get());
+//        }
         
         
 //        for (int i = 0; i < parametersCopy.size(); i++){


### PR DESCRIPTION
- Update baseScene to correctly reset parameters upon scene start
- Re-assign knobs to be numbered 1-4 from left to right
- Synchronize LED activation with animation start sound