### PR TITLE
Case must be respected on case sensitive filesystems

### DIFF
--- a/addons.make
+++ b/addons.make
@@ -1,4 +1,4 @@
 ofxGui
 ofxXmlSettings
-ofxOSC
+ofxOsc
 ofxMidi

--- a/src/scenes/yeseulRileyBrokencircle/yeseulRileyBrokencircle.cpp
+++ b/src/scenes/yeseulRileyBrokencircle/yeseulRileyBrokencircle.cpp
@@ -1,5 +1,5 @@
 
-#include "yeseulRileybrokencircle.h"
+#include "yeseulRileyBrokencircle.h"
 
 
 void yeseulRileyBrokencircle::setup(){


### PR DESCRIPTION
Case must be respected on case sensitive filesystems (like ext4 or HFS+ configured as case sensitive) otherwise compilation fails.